### PR TITLE
fix014

### DIFF
--- a/pyprql/cli/cli.py
+++ b/pyprql/cli/cli.py
@@ -465,7 +465,6 @@ class CLI:
                 if "SELECT" in sql and "LIMIT" not in sql:
                     sql += " LIMIT 25"
 
-                print("\t" + self.highlight_sql(sql))
                 self.prompt_text = "SQL> "
                 self.execute_sql(sql)
 


### PR DESCRIPTION
To prevent redundeancy, the generated SQL query is no longer printed in SQL mode only.

Closes #14.
